### PR TITLE
Divide stats collector in sub-collectors

### DIFF
--- a/collector/nsqd.go
+++ b/collector/nsqd.go
@@ -1,0 +1,62 @@
+package collector
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// StatsCollector defines an interface for collecting specific stats
+// from a nsqd node.
+type StatsCollector interface {
+	collect(s *stats, out chan<- prometheus.Metric)
+}
+
+// NsqdStats represents a Collector which collects all the configured stats
+// from a nsqd node. Besides the configured stats it will also expose a
+// metric for the total number of existing topics.
+type NsqdStats struct {
+	nsqdURL    string
+	collectors []StatsCollector
+	topicCount prometheus.Gauge
+}
+
+// NewNsqdStats creates a new stats collector which uses the given namespace
+// and reads the stats from the given URL of the nsqd.
+func NewNsqdStats(namespace, nsqdURL string) *NsqdStats {
+	return &NsqdStats{
+		nsqdURL: nsqdURL,
+		topicCount: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "topics_total",
+			Help:      "The total number of topics",
+		}),
+	}
+}
+
+// Use configures a specific stats collector, so the stats could be
+// exposed to the Prometheus system.
+func (s *NsqdStats) Use(c StatsCollector) {
+	s.collectors = append(s.collectors, c)
+}
+
+// Collect collects all the registered stats metrics from the nsqd node.
+func (s *NsqdStats) Collect(out chan<- prometheus.Metric) error {
+	stats, err := getNsqdStats(s.nsqdURL)
+	if err != nil {
+		return err
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(len(s.collectors))
+	for _, coll := range s.collectors {
+		go func(coll StatsCollector) {
+			coll.collect(stats, out)
+			wg.Done()
+		}(coll)
+	}
+
+	s.topicCount.Set(float64(len(stats.Topics)))
+	wg.Wait()
+	return nil
+}

--- a/collector/stats_channel.go
+++ b/collector/stats_channel.go
@@ -6,29 +6,26 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-// see https://github.com/nsqio/nsq/blob/master/nsqd/stats.go
-type channel struct {
-	Name          string    `json:"channel_name"`
-	Depth         int64     `json:"depth"`
-	BackendDepth  int64     `json:"backend_depth"`
-	InFlightCount int       `json:"in_flight_count"`
-	DeferredCount int       `json:"deferred_count"`
-	MessageCount  uint64    `json:"message_count"`
-	RequeueCount  uint64    `json:"requeue_count"`
-	TimeoutCount  uint64    `json:"timeout_count"`
-	Clients       []*client `json:"clients"`
-	Paused        bool      `json:"paused"`
-}
-
-type channelCollector []struct {
+type channelsCollector []struct {
 	val func(*channel) float64
 	vec *prometheus.GaugeVec
 }
 
-func newChannelCollector(namespace string) channelCollector {
+// ChannelsCollector creates a new stats collector which is able to
+// expose the channel metrics of a nsqd node to Prometheus. The
+// channel metrics are reported per topic.
+func ChannelsCollector(namespace string) StatsCollector {
 	labels := []string{"type", "topic", "channel", "paused"}
 
-	return channelCollector{
+	return channelsCollector{
+		{
+			val: func(c *channel) float64 { return float64(len(c.Clients)) },
+			vec: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+				Namespace: namespace,
+				Name:      "client_count",
+				Help:      "Number of clients",
+			}, labels),
+		},
 		{
 			val: func(c *channel) float64 { return float64(c.Depth) },
 			vec: prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -88,16 +85,20 @@ func newChannelCollector(namespace string) channelCollector {
 	}
 }
 
-func (c channelCollector) update(topic string, ch *channel, out chan<- prometheus.Metric) {
-	labels := prometheus.Labels{
-		"type":    "channel",
-		"topic":   topic,
-		"channel": ch.Name,
-		"paused":  strconv.FormatBool(ch.Paused),
-	}
+func (coll channelsCollector) collect(s *stats, out chan<- prometheus.Metric) {
+	for _, topic := range s.Topics {
+		for _, channel := range topic.Channels {
+			labels := prometheus.Labels{
+				"type":    "channel",
+				"topic":   topic.Name,
+				"channel": channel.Name,
+				"paused":  strconv.FormatBool(channel.Paused),
+			}
 
-	for _, g := range c {
-		g.vec.With(labels).Set(g.val(ch))
-		g.vec.Collect(out)
+			for _, c := range coll {
+				c.vec.With(labels).Set(c.val(channel))
+				c.vec.Collect(out)
+			}
+		}
 	}
 }

--- a/collector/stats_channel.go
+++ b/collector/stats_channel.go
@@ -6,18 +6,18 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-type channelsCollector []struct {
+type channelStats []struct {
 	val func(*channel) float64
 	vec *prometheus.GaugeVec
 }
 
-// ChannelsCollector creates a new stats collector which is able to
+// ChannelStats creates a new stats collector which is able to
 // expose the channel metrics of a nsqd node to Prometheus. The
 // channel metrics are reported per topic.
-func ChannelsCollector(namespace string) StatsCollector {
+func ChannelStats(namespace string) StatsCollector {
 	labels := []string{"type", "topic", "channel", "paused"}
 
-	return channelsCollector{
+	return channelStats{
 		{
 			val: func(c *channel) float64 { return float64(len(c.Clients)) },
 			vec: prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -85,7 +85,7 @@ func ChannelsCollector(namespace string) StatsCollector {
 	}
 }
 
-func (coll channelsCollector) collect(s *stats, out chan<- prometheus.Metric) {
+func (cs channelStats) collect(s *stats, out chan<- prometheus.Metric) {
 	for _, topic := range s.Topics {
 		for _, channel := range topic.Channels {
 			labels := prometheus.Labels{
@@ -95,7 +95,7 @@ func (coll channelsCollector) collect(s *stats, out chan<- prometheus.Metric) {
 				"paused":  strconv.FormatBool(channel.Paused),
 			}
 
-			for _, c := range coll {
+			for _, c := range cs {
 				c.vec.With(labels).Set(c.val(channel))
 				c.vec.Collect(out)
 			}

--- a/collector/stats_topic.go
+++ b/collector/stats_topic.go
@@ -6,17 +6,17 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-type topicsCollector []struct {
+type topicStats []struct {
 	val func(*topic) float64
 	vec *prometheus.GaugeVec
 }
 
-// TopicsCollector creates a new stats collector which is able to
+// TopicStats creates a new stats collector which is able to
 // expose the topic metrics of a nsqd node to Prometheus.
-func TopicsCollector(namespace string) StatsCollector {
+func TopicStats(namespace string) StatsCollector {
 	labels := []string{"type", "topic", "paused"}
 
-	return topicsCollector{
+	return topicStats{
 		{
 			val: func(t *topic) float64 { return float64(len(t.Channels)) },
 			vec: prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -52,7 +52,7 @@ func TopicsCollector(namespace string) StatsCollector {
 	}
 }
 
-func (coll topicsCollector) collect(s *stats, out chan<- prometheus.Metric) {
+func (ts topicStats) collect(s *stats, out chan<- prometheus.Metric) {
 	for _, topic := range s.Topics {
 		labels := prometheus.Labels{
 			"type":   "topic",
@@ -60,7 +60,7 @@ func (coll topicsCollector) collect(s *stats, out chan<- prometheus.Metric) {
 			"paused": strconv.FormatBool(topic.Paused),
 		}
 
-		for _, c := range coll {
+		for _, c := range ts {
 			c.vec.With(labels).Set(c.val(topic))
 			c.vec.Collect(out)
 		}

--- a/collector/stats_topic.go
+++ b/collector/stats_topic.go
@@ -6,25 +6,25 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-// see https://github.com/nsqio/nsq/blob/master/nsqd/stats.go
-type topic struct {
-	Name         string     `json:"topic_name"`
-	Channels     []*channel `json:"channels"`
-	Depth        int64      `json:"depth"`
-	BackendDepth int64      `json:"backend_depth"`
-	MessageCount uint64     `json:"message_count"`
-	Paused       bool       `json:"paused"`
-}
-
-type topicCollector []struct {
+type topicsCollector []struct {
 	val func(*topic) float64
 	vec *prometheus.GaugeVec
 }
 
-func newTopicCollector(namespace string) topicCollector {
+// TopicsCollector creates a new stats collector which is able to
+// expose the topic metrics of a nsqd node to Prometheus.
+func TopicsCollector(namespace string) StatsCollector {
 	labels := []string{"type", "topic", "paused"}
 
-	return topicCollector{
+	return topicsCollector{
+		{
+			val: func(t *topic) float64 { return float64(len(t.Channels)) },
+			vec: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+				Namespace: namespace,
+				Name:      "channel_count",
+				Help:      "Number of channels",
+			}, labels),
+		},
 		{
 			val: func(t *topic) float64 { return float64(t.Depth) },
 			vec: prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -52,15 +52,17 @@ func newTopicCollector(namespace string) topicCollector {
 	}
 }
 
-func (c topicCollector) update(t *topic, out chan<- prometheus.Metric) {
-	labels := prometheus.Labels{
-		"type":   "topic",
-		"topic":  t.Name,
-		"paused": strconv.FormatBool(t.Paused),
-	}
+func (coll topicsCollector) collect(s *stats, out chan<- prometheus.Metric) {
+	for _, topic := range s.Topics {
+		labels := prometheus.Labels{
+			"type":   "topic",
+			"topic":  topic.Name,
+			"paused": strconv.FormatBool(topic.Paused),
+		}
 
-	for _, g := range c {
-		g.vec.With(labels).Set(g.val(t))
-		g.vec.Collect(out)
+		for _, c := range coll {
+			c.vec.With(labels).Set(c.val(topic))
+			c.vec.Collect(out)
+		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -29,9 +29,9 @@ var (
 
 	// stats.* collectors
 	statsRegistry = map[string]func(namespace string) collector.StatsCollector{
-		"topics":   collector.TopicsCollector,
-		"channels": collector.ChannelsCollector,
-		"clients":  collector.ClientsCollector,
+		"topics":   collector.TopicStats,
+		"channels": collector.ChannelStats,
+		"clients":  collector.ClientStats,
 	}
 )
 

--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/tsne/nsq_exporter/collector"
+	"github.com/lovoo/nsq_exporter/collector"
 
 	"github.com/prometheus/client_golang/prometheus"
 )


### PR DESCRIPTION
When many clients are tracked by the nsqd node, collecting the metrics could be very slow and end in a timeout. To avoid those situations it should be possible to choose only the stats that are needed. So one can omit the client stats to improve the collection performance.

This pull request divides the original "stats" collector into the following collectors:
 * "stats.topics": exposes the topic stats
 * "stats.channels": exposes the channel stats per topic
 * "stats.clients": exposes the client stats per channel and topic

Each of these selectors can be enabled separately via a command line parameter.