### PR TITLE
Add TLS support for nsqd stats connections.

### DIFF
--- a/collector/stats.go
+++ b/collector/stats.go
@@ -84,9 +84,8 @@ func getPercentile(t *topic, percentile int) float64 {
 	return 0
 }
 
-func getNsqdStats(nsqdURL string) (*stats, error) {
-
-	resp, err := http.Get(nsqdURL)
+func getNsqdStats(client *http.Client, nsqdURL string) (*stats, error) {
+	resp, err := client.Get(nsqdURL)
 	if err != nil {
 		return nil, err
 	}

--- a/main.go
+++ b/main.go
@@ -22,6 +22,9 @@ var (
 	nsqdURL           = flag.String("nsqd.addr", "http://localhost:4151/stats", "Address of the nsqd node.")
 	enabledCollectors = flag.String("collect", "stats.topics,stats.channels", "Comma-separated list of collectors to use.")
 	namespace         = flag.String("namespace", "nsq", "Namespace for the NSQ metrics.")
+	tlsCACert         = flag.String("tls.ca_cert", "", "CA certificate file to be used for nsqd connections.")
+	tlsCert           = flag.String("tls.cert", "", "TLS certificate file to be used for client connections to nsqd.")
+	tlsKey            = flag.String("tls.key", "", "TLS key file to be used for TLS client connections to nsqd.")
 
 	statsRegistry = map[string]func(namespace string) collector.StatsCollector{
 		"topics":   collector.TopicStats,
@@ -60,13 +63,15 @@ func main() {
 }
 
 func createNsqExecutor() (*collector.NsqExecutor, error) {
-
 	nsqdURL, err := normalizeURL(*nsqdURL)
 	if err != nil {
 		return nil, err
 	}
 
-	ex := collector.NewNsqExecutor(*namespace, nsqdURL)
+	ex, err := collector.NewNsqExecutor(*namespace, nsqdURL, *tlsCACert, *tlsCert, *tlsKey)
+	if err != nil {
+		log.Fatal(err)
+	}
 	for _, param := range strings.Split(*enabledCollectors, ",") {
 		param = strings.TrimSpace(param)
 		parts := strings.SplitN(param, ".", 2)


### PR DESCRIPTION
In our environment client connections to NSQd use TLS x509 authentication. This patch adds support for providing a TLS client certificate, key and optional CA certificate that can be used to authenticate the connection to nsqd from the exporter.