### PR TITLE
fixed wrongly named arguments in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ NSQ exporter for prometheus.io, written in go.
 
 ## Usage
 
-    docker run -d --name nsq_exporter -l nsqd:nsqd -p 9117:9117 lovoo/nsq_exporter:latest -nsq.addr=http://nsqd:4151 -collectors=nsqstats
+    docker run -d --name nsq_exporter -l nsqd:nsqd -p 9117:9117 lovoo/nsq_exporter:latest -nsqd.addr=http://nsqd:4151 -collect=stats.topics,stats.channels,stats.clients
 
 ## Building
 


### PR DESCRIPTION
the arguments in the README are wrong and lead to nsq-exporter not starting/working