### PR TITLE
Fixed the NSQ stats response

### DIFF
--- a/collector/stats.go
+++ b/collector/stats.go
@@ -91,9 +91,9 @@ func getNsqdStats(client *http.Client, nsqdURL string) (*stats, error) {
 	}
 	defer resp.Body.Close()
 
-	var sr statsResponse
+	var sr stats
 	if err = json.NewDecoder(resp.Body).Decode(&sr); err != nil {
 		return nil, err
 	}
-	return &sr.Data, nil
+	return &sr, nil
 }


### PR DESCRIPTION
This fixes the NSQ stats not being returned.

The json response from the exporter is:
```json
{
  "version": "1.0.0-compat",
  "health": "OK",
  "start_time": 1535059652,
  "topics": []
}
```

But the struct being hydrated was:
```go
type statsResponse struct {
	StatusCode int    `json:"status_code"`
	StatusText string `json:"status_text"`
	Data       stats  `json:"data"`
}
```

I used the `stat` struct instead:
```go
type stats struct {
	Version   string   `json:"version"`
	Health    string   `json:"health"`
	StartTime int64    `json:"start_time"`
	Topics    []*topic `json:"topics"`
}
```